### PR TITLE
Update zig-sdl3 to master

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,7 @@
     .dependencies = .{
         .sdl3 = .{
             .url = "https://github.com/Gota7/zig-sdl3/archive/refs/heads/master.zip",
-            .hash = "sdl3-0.0.1-NmT1QxgLHADH3iLiD44LpAGHGP1M5vJ5cHFfaylBBXfK",
+            .hash = "sdl3-0.0.1-NmT1Q9w4HACobSKMy4Nr6Pxef11nQI4WZ-6lPUX1pxlE",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,7 +3,7 @@
     .version = "0.0.0",
     .dependencies = .{
         .sdl3 = .{
-            .url = "https://github.com/Gota7/zig-sdl3/archive/refs/heads/master.zip",
+            .url = "git+https://github.com/Gota7/zig-sdl3#0f4174f3234732c8570b89616c76d7e73fb4ae66",
             .hash = "sdl3-0.0.1-NmT1Q9w4HACobSKMy4Nr6Pxef11nQI4WZ-6lPUX1pxlE",
         },
     },

--- a/src/main.zig
+++ b/src/main.zig
@@ -71,26 +71,26 @@ fn sdlErr(
 /// Since SDL's logging callbacks must be C-compatible, you may have to wrap the `category` and `priority` to managed types for convenience.
 fn sdlLog(
     user_data: ?*anyopaque,
-    category: c_int,
-    priority: sdl3.c.SDL_LogPriority,
-    message: [*c]const u8,
-) callconv(.c) void {
+    category: ?sdl3.log.Category,
+    priority: ?sdl3.log.Priority,
+    message: [:0]const u8,
+) void {
     _ = user_data;
-    const category_managed = sdl3.log.Category.fromSdl(category);
-    const category_str: ?[]const u8 = if (category_managed) |val| switch (val.value) {
-        sdl3.log.Category.application.value => "Application",
-        sdl3.log.Category.errors.value => "Errors",
-        sdl3.log.Category.assert.value => "Assert",
-        sdl3.log.Category.system.value => "System",
-        sdl3.log.Category.audio.value => "Audio",
-        sdl3.log.Category.video.value => "Video",
-        sdl3.log.Category.render.value => "Render",
-        sdl3.log.Category.input.value => "Input",
-        sdl3.log.Category.testing.value => "Testing",
-        sdl3.log.Category.gpu.value => "Gpu",
+    const category_managed = category;
+    const category_str: ?[]const u8 = if (category_managed) |val| switch (val) {
+        sdl3.log.Category.application => "Application",
+        sdl3.log.Category.errors => "Errors",
+        sdl3.log.Category.assert => "Assert",
+        sdl3.log.Category.system => "System",
+        sdl3.log.Category.audio => "Audio",
+        sdl3.log.Category.video => "Video",
+        sdl3.log.Category.render => "Render",
+        sdl3.log.Category.input => "Input",
+        sdl3.log.Category.testing => "Testing",
+        sdl3.log.Category.gpu => "Gpu",
         else => null,
     } else null;
-    const priority_managed = sdl3.log.Priority.fromSdl(priority);
+    const priority_managed = priority;
     const priority_str: [:0]const u8 = if (priority_managed) |val| switch (val) {
         .trace => "Trace",
         .verbose => "Verbose",
@@ -103,7 +103,7 @@ fn sdlLog(
     if (category_str) |val| {
         std.debug.print("[{s}:{s}] {s}\n", .{ val, priority_str, message });
     } else {
-        std.debug.print("[Custom_{d}:{s}] {s}\n", .{ category, priority_str, message });
+        std.debug.print("[Custom_{?}:{s}] {s}\n", .{ category, priority_str, message });
     }
 }
 
@@ -116,13 +116,13 @@ pub fn main() !void {
     // Setup logging.
     sdl3.errors.error_callback = &sdlErr;
     sdl3.log.setAllPriorities(.info);
-    sdl3.log.setLogOutputFunction(sdlLog, null);
+    sdl3.log.setLogOutputFunction(anyopaque, sdlLog, null);
 
     // Setup SDL3.
-    defer sdl3.init.shutdown();
-    const init_flags = sdl3.init.Flags{ .video = true, .gamepad = true };
-    try sdl3.init.init(init_flags);
-    defer sdl3.init.quit(init_flags);
+    defer sdl3.shutdown();
+    const init_flags = sdl3.InitFlags{ .video = true, .gamepad = true };
+    try sdl3.init(init_flags);
+    defer sdl3.quit(init_flags);
 
     // Setup initial example.
     var example_index: usize = starting_example;

--- a/src/main.zig
+++ b/src/main.zig
@@ -66,9 +66,6 @@ fn sdlErr(
 /// * `category`: Which category SDL is logging under, for example "video".
 /// * `priority`: Which priority the log message is.
 /// * `message`: Actual message to log. This should not be `null`.
-///
-/// ## Remarks
-/// Since SDL's logging callbacks must be C-compatible, you may have to wrap the `category` and `priority` to managed types for convenience.
 fn sdlLog(
     user_data: ?*anyopaque,
     category: ?sdl3.log.Category,
@@ -76,22 +73,20 @@ fn sdlLog(
     message: [:0]const u8,
 ) void {
     _ = user_data;
-    const category_managed = category;
-    const category_str: ?[]const u8 = if (category_managed) |val| switch (val) {
-        sdl3.log.Category.application => "Application",
-        sdl3.log.Category.errors => "Errors",
-        sdl3.log.Category.assert => "Assert",
-        sdl3.log.Category.system => "System",
-        sdl3.log.Category.audio => "Audio",
-        sdl3.log.Category.video => "Video",
-        sdl3.log.Category.render => "Render",
-        sdl3.log.Category.input => "Input",
-        sdl3.log.Category.testing => "Testing",
-        sdl3.log.Category.gpu => "Gpu",
+    const category_str: ?[]const u8 = if (category) |val| switch (val) {
+        .application => "Application",
+        .errors => "Errors",
+        .assert => "Assert",
+        .system => "System",
+        .audio => "Audio",
+        .video => "Video",
+        .render => "Render",
+        .input => "Input",
+        .testing => "Testing",
+        .gpu => "Gpu",
         else => null,
     } else null;
-    const priority_managed = priority;
-    const priority_str: [:0]const u8 = if (priority_managed) |val| switch (val) {
+    const priority_str: [:0]const u8 = if (priority) |val| switch (val) {
         .trace => "Trace",
         .verbose => "Verbose",
         .debug => "Debug",


### PR DESCRIPTION
This pr updates the zig-sdl3 package to master(`b91d121b906f12ab07f3899260cdce37c25886d2`). It also tags the specific commit rather than master. It also simplifies some of the `sdlLog` function.